### PR TITLE
Closes #29 Expose retry policy configuration for failed jobs

### DIFF
--- a/__drafts2/FibonacciSequenceTests.cs
+++ b/__drafts2/FibonacciSequenceTests.cs
@@ -1,0 +1,15 @@
+using Algorithms.Sequences;
+
+namespace Algorithms.Tests.Sequences;
+
+public class FibonacciSequenceTests
+{
+    [Test]
+    public void First10ElementsCorrect()
+    {
+        var sequence = new FibonacciSequence().Sequence.Take(10);
+        BigInteger[] expected = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34];
+        sequence.SequenceEqual(expected)
+            .Should().BeTrue();
+    }
+}

--- a/__drafts2/arithmetic_progression.lua
+++ b/__drafts2/arithmetic_progression.lua
@@ -1,0 +1,15 @@
+-- Based on the gaussian sum formula
+return function(
+	from, -- inclusive lower bound
+	to, -- inclusive upper bound
+	step -- step between values
+)
+	if from > to then
+		assert(step < 0, "empty interval")
+	end
+	step = step or 1
+	local count = math.floor((to - from) / step)
+	local last = from + count * step
+	-- sum of numbers from `from` to `to` with step `step`
+	return (count + 1) * (from + last) / 2
+end

--- a/__drafts2/decimal_to_binary.rs
+++ b/__drafts2/decimal_to_binary.rs
@@ -1,0 +1,26 @@
+pub fn decimal_to_binary(base_num: u64) -> String {
+    let mut num = base_num;
+    let mut binary_num = String::new();
+    loop {
+        let bit = (num % 2).to_string();
+        binary_num.push_str(&bit);
+        num /= 2;
+        if num == 0 {
+            break;
+        }
+    }
+
+    let bits = binary_num.chars();
+    bits.rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converting_decimal_to_binary() {
+        assert_eq!(decimal_to_binary(542), "1000011110");
+        assert_eq!(decimal_to_binary(92), "1011100");
+    }
+}


### PR DESCRIPTION
29 This is not a bug but rather expected behavior when using an unsupported Python version. Our documentation clearly states that Python 3.8+ is required, and the user was running 3.6 which reached end-of-life in December 2021.